### PR TITLE
Add explanation of browse show to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -122,6 +122,10 @@ __COMMANDS:__
 
 &emsp;現在のプロジェクトのリポジトリ一覧ページを開きます。
 
+`gitb browse show`
+
+&emsp;与えられたファイルまたはディレクトリの該当するページを開きます。
+
 ## エイリアス
 
 `gitb <command>`を`git <command>`として使いたい場合は、.XXXrc（.bashrc、.zshrc、config.fish）に以下のエイリアスを書いてください。

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ __COMMANDS:__
 
 &emsp;Open the repository list page in the current project.
 
+`gitb browse show`
+
+&emsp;Open the corresponding page to given file or directory in current project.
+
 ## Alias 
 
 Please write an alias to .XXXrc (.bashrc, .zshrc, config.fish) if you want to use `gitb <command>` as `git <command>`.


### PR DESCRIPTION
I added explanations of `browse show` command to README.md and README.ja.md.
The command was added in #32 