### PR TITLE
browse commit <hash>

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -126,6 +126,10 @@ __COMMANDS:__
 
 &emsp;与えられたファイルまたはディレクトリの該当するページを開きます。
 
+`gitb browse commit <hash>`
+
+&emsp;与えられたハッシュのコミットページを開きます。
+
 ## エイリアス
 
 `gitb <command>`を`git <command>`として使いたい場合は、.XXXrc（.bashrc、.zshrc、config.fish）に以下のエイリアスを書いてください。

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ __COMMANDS:__
 
 &emsp;Open the corresponding page to given file or directory in current project.
 
+`gitb browse commit <hash>`
+
+&emsp;Open the commit page to given hash in current project.
+
 ## Alias 
 
 Please write an alias to .XXXrc (.bashrc, .zshrc, config.fish) if you want to use `gitb <command>` as `git <command>`.

--- a/builder.go
+++ b/builder.go
@@ -77,6 +77,10 @@ func (b *BacklogURLBuilder) TagListURL() string {
 	return b.GitRepoBaseURL() + path.Join("/", "tags")
 }
 
+func (b *BacklogURLBuilder) CommitURL(hash string) string {
+	return b.GitRepoBaseURL() + path.Join("/", "commit", hash)
+}
+
 func (b *BacklogURLBuilder) PullRequestListURL(statusID int) string {
 	var q string
 	if statusID > 0 {

--- a/builder_test.go
+++ b/builder_test.go
@@ -710,3 +710,42 @@ func TestBacklogURLBuilder_IssueListURL(t *testing.T) {
 		})
 	}
 }
+
+func TestBacklogURLBuilder_CommitURL(t *testing.T) {
+	type fields struct {
+		domain     string
+		spaceKey   string
+		projectKey string
+		repoName   string
+		hash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			fields: fields{
+				"backlog.com",
+				"foo",
+				"BAR",
+				"baz",
+				"qux",
+			},
+			want: "https://foo.backlog.com/git/BAR/baz/commit/qux",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BacklogURLBuilder{
+				domain:     tt.fields.domain,
+				spaceKey:   tt.fields.spaceKey,
+				projectKey: tt.fields.projectKey,
+				repoName:   tt.fields.repoName,
+			}
+			if got := b.CommitURL(tt.fields.hash); got != tt.want {
+				t.Errorf("BacklogURLBuilder.CommitURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -251,6 +251,21 @@ func main() {
 						return exit(repo.OpenObject(fileUrl.Path, fs.IsDir(), line))
 					},
 				},
+				{
+					Name:  "commit",
+					Usage: "Open the network page in current branch",
+					Action: func(c *cli.Context) error {
+						repo, err := open(".")
+						if err != nil {
+							return exit(err)
+						}
+						hash := c.Args().First()
+						if len(hash) == 0 {
+							return exit(err)
+						}
+						return exit(repo.OpenCommit(hash))
+					},
+				},
 			},
 		},
 	}

--- a/repository.go
+++ b/repository.go
@@ -195,6 +195,13 @@ func (b *BacklogRepository) OpenHistory(refOrHash string) error {
 		HistoryURL(refOrHash))
 }
 
+func (b *BacklogRepository) OpenCommit(hash string) error {
+	return b.openBrowser(NewBacklogURLBuilder(b.domain, b.spaceKey).
+		SetProjectKey(b.projectKey).
+		SetRepoName(b.repoName).
+		CommitURL(hash))
+}
+
 func (b *BacklogRepository) OpenNetwork(refOrHash string) error {
 	if refOrHash == "" {
 		refOrHash = b.repo.HeadShortName()

--- a/repository_test.go
+++ b/repository_test.go
@@ -1288,3 +1288,53 @@ func TestBacklogRepository_OpenIssueList(t *testing.T) {
 		})
 	}
 }
+
+func TestBacklogRepository_OpenCommit(t *testing.T) {
+	type fields struct {
+		openBrowser func(url string) error
+		repo        Repository
+		domain      string
+		spaceKey    string
+		projectKey  string
+		repoName    string
+		hash        string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			fields: fields{
+				openBrowser: func(url string) error {
+					want := "https://foo.backlog.com/git/BAR/baz/commit/qux"
+					if url != want {
+						return errors.New(fmt.Sprintf("result %v, want %v", url, want))
+					}
+					return nil
+				},
+				domain:     "backlog.com",
+				spaceKey:   "foo",
+				projectKey: "BAR",
+				repoName:   "baz",
+				hash:       "qux",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BacklogRepository{
+				openBrowser: tt.fields.openBrowser,
+				repo:        tt.fields.repo,
+				domain:      tt.fields.domain,
+				spaceKey:    tt.fields.spaceKey,
+				projectKey:  tt.fields.projectKey,
+				repoName:    tt.fields.repoName,
+			}
+			if err := b.OpenCommit(tt.fields.hash); (err != nil) != tt.wantErr {
+				t.Errorf("BacklogRepository.OpenCommit() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi, @vvatanabe 

This change introduces the new option-- `gitb browse commit <hash>` which allows to open <hash>'s commit page like https://foo.backlog.jp/git/bar/baz/commit/01234deadbeaf

thanks,